### PR TITLE
Use kernel mapping helper

### DIFF
--- a/src/sb_utils.py
+++ b/src/sb_utils.py
@@ -21,6 +21,15 @@ def polynomial_kernel(x, H, degree=3):
     return (1 + x / H) ** degree
 
 
+# Mapping of kernel names to their corresponding implementations
+KERNELS = {
+    "default": default_kernel,
+    "gaussian": gaussian_kernel,
+    "laplacian": laplacian_kernel,
+    "polynomial": polynomial_kernel,
+}
+
+
 def schedule(timeEuler, maturity, timestep):
     """Append time points to ``timeEuler`` from 0 to ``maturity``."""
     timeEuler.extend(np.arange(0, maturity, timestep))

--- a/src/schrodinger_bridge.py
+++ b/src/schrodinger_bridge.py
@@ -1,13 +1,7 @@
 import numpy as np
 from tqdm import tqdm
 
-from .sb_utils import (
-    default_kernel,
-    gaussian_kernel,
-    laplacian_kernel,
-    polynomial_kernel,
-    schedule as sb_schedule,
-)
+from .sb_utils import KERNELS, schedule as sb_schedule
 
 class SchrodingerBridgeMulti:
     def __init__(self, distSize, nbpaths, dimension, timeSeriesDataVector, kernel_type='default'):
@@ -24,16 +18,10 @@ class SchrodingerBridgeMulti:
         self.weights_tilde = np.zeros(nbpaths)
 
         # Kernel selection
-        if kernel_type == 'default':
-            self.kernel = default_kernel
-        elif kernel_type == 'gaussian':
-            self.kernel = gaussian_kernel
-        elif kernel_type == 'laplacian':
-            self.kernel = laplacian_kernel
-        elif kernel_type == 'polynomial':
-            self.kernel = polynomial_kernel
-        else:
-            raise ValueError("Unsupported kernel type: {}".format(kernel_type))
+        try:
+            self.kernel = KERNELS[kernel_type]
+        except KeyError:
+            raise KeyError(f"Unknown kernel type: {kernel_type}")
 
     def schedule(self, timeEuler, maturity, timestep):
         sb_schedule(timeEuler, maturity, timestep)
@@ -90,16 +78,10 @@ class SchrodingerBridge:
         self.weights_tilde = np.zeros(nbpaths)
     
         # Kernel selection
-        if kernel_type == 'default':
-            self.kernel = default_kernel
-        elif kernel_type == 'gaussian':
-            self.kernel = gaussian_kernel
-        elif kernel_type == 'laplacian':
-            self.kernel = laplacian_kernel
-        elif kernel_type == 'polynomial':
-            self.kernel = polynomial_kernel
-        else:
-            raise ValueError("Unsupported kernel type: {}".format(kernel_type))
+        try:
+            self.kernel = KERNELS[kernel_type]
+        except KeyError:
+            raise KeyError(f"Unknown kernel type: {kernel_type}")
 
     def simulate_kernel(self, nbStepsPerDeltati, H, deltati):
         vtimestepEuler = np.arange(0, deltati + deltati / nbStepsPerDeltati, deltati / nbStepsPerDeltati)


### PR DESCRIPTION
## Summary
- centralize available kernels in `KERNELS` mapping
- use that mapping in `SchrodingerBridge` classes

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install -r requirements.txt` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_687e25ced7dc8322870b74bc3785c6fe