### PR TITLE
Add demo animation script and instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,15 @@ bridge = SchrodingerBridge(distSize=60, nbpaths=windows.shape[0],
 
    The script expects the data arrays created in the notebooks and saves the resulting GIFs to the `images/` directory.
 
+For a quick demonstration using randomly generated data, run the following script:
+
+```bash
+python demo_animation.py
+```
+
+This will create a GIF named `demo_square.gif` inside the `images/` folder.
+
+
 
 ## Performance evaluation
 The performance of the generative model is evaluated through various experiments on financial datasets, assessing metrics such as accuracy, robustness and applicability to real-world scenarios.

--- a/demo_animation.py
+++ b/demo_animation.py
@@ -1,0 +1,21 @@
+import numpy as np
+from animation_creation import create_animation
+
+
+def generate_moving_square_frames(num_frames=30, size=32, square_size=8):
+    """Generate frames showing a square moving horizontally."""
+    frames = np.zeros((num_frames, size, size))
+    for i in range(num_frames):
+        start = (i * (size - square_size)) // (num_frames - 1)
+        frames[i, 8:8 + square_size, start:start + square_size] = 1
+    return frames
+
+
+def main():
+    data = generate_moving_square_frames()
+    create_animation(data, base_name="demo_square", speed=10, step=1)
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
## Summary
- add a small `demo_animation.py` script that generates a simple moving square animation
- document how to run the demo in the README

## Testing
- `pip install -q -r requirements.txt` *(fails: Tunnel connection failed)*
- `python demo_animation.py` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_687e25e1d65883228fcadd8064303fa7